### PR TITLE
Create environment before building app

### DIFF
--- a/.github/workflows/build_on_release.yml
+++ b/.github/workflows/build_on_release.yml
@@ -33,6 +33,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    
+    - name: Create .env file (using API_KEY)
+      run: |
+        echo "X_API=$env:API_KEY" > .env
+        echo ".env file created with API_KEY"
 
     - name: Build On Windows
       run: |
@@ -70,8 +75,3 @@ jobs:
         asset_path: dist/EasyPunchCard_setup.exe
         asset_name: EasyPunchCard.exe
         asset_content_type: application/octet-stream
-
-    - name: Create .env file (using API_KEY)
-      run: |
-        echo "X_API=$env:API_KEY" > .env
-        echo ".env file created with API_KEY"


### PR DESCRIPTION
Environment was being created after uploading release asset; therefore, it could not build the exe because there was no environment.